### PR TITLE
Rename unique constraint helper

### DIFF
--- a/server/src/service.rs
+++ b/server/src/service.rs
@@ -156,7 +156,7 @@ id, title, amount, source_account_id, destination_account_id, category, posting_
         let mut tx = self.start_psql_transaction().await?;
 
         let account_id = self.save_account(&mut tx, req).await.map_err(|e| {
-            if is_unique_constraing_violation(&e) {
+            if is_unique_constraint_violation(&e) {
                 CreateAccountError::Duplicate { name: req.clone() }
             } else {
                 anyhow!(e)
@@ -295,7 +295,7 @@ WHERE id = $2
         .execute(&self.pool)
         .await
         .map_err(|e| {
-            if is_unique_constraing_violation(&e) {
+            if is_unique_constraint_violation(&e) {
                 UpdateAccountError::Duplicate {
                     name: new_name.to_string(),
                 }
@@ -568,7 +568,7 @@ const UNIQUE_CONSTRAINT_VIOLATION_CODE: &str = "23505";
 /// Check if an error happened due to a unique constraint violation.
 ///
 /// This means that the record had a duplicate.
-fn is_unique_constraing_violation(err: &sqlx::Error) -> bool {
+fn is_unique_constraint_violation(err: &sqlx::Error) -> bool {
     if let sqlx::Error::Database(db_err) = err {
         if let Some(code) = db_err.code() {
             return code == UNIQUE_CONSTRAINT_VIOLATION_CODE;


### PR DESCRIPTION
## Summary
- fix service unique constraint violation helper name

## Testing
- `cargo test --manifest-path server/Cargo.toml --quiet` *(fails: could not finish building due to environment limits)*
- `cargo fmt --manifest-path server/Cargo.toml` *(fails: rustfmt not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684369865fb0832dbad87e058a54a0f9